### PR TITLE
Add host-spawn, for running MCP servers

### DIFF
--- a/flatpak.yaml
+++ b/flatpak.yaml
@@ -37,3 +37,14 @@ modules:
         commands:
           - exec /app/anythingllm-desktop/anythingllm-desktop --no-sandbox  "$@"
       - sources.json
+  - name: host-spawn
+    buildsystem: simple
+    build-commands:
+      - install -Dm755 host-spawn /app/bin/host-spawn
+    sources:
+      - type: file
+        url: https://github.com/1player/host-spawn/releases/download/v1.6.1/host-spawn-x86_64
+        sha256: 733746ab498e07d065cbecf80bacd447eb21846d1462e8fe23fdd9d9dc977b50
+        dest-filename: host-spawn
+        only-arches:
+          - x86_64


### PR DESCRIPTION
stdio MCP servers do not work if launched using `flatpak-spawn --host`.
