### PR TITLE
Add --ozone-platform-hint=auto argument to launch app

### DIFF
--- a/flatpak.yaml
+++ b/flatpak.yaml
@@ -35,7 +35,7 @@ modules:
       - type: script
         dest-filename: run.sh
         commands:
-          - exec /app/anythingllm-desktop/anythingllm-desktop --no-sandbox  "$@"
+          - exec /app/anythingllm-desktop/anythingllm-desktop --no-sandbox --ozone-platform-hint=auto "$@"
       - sources.json
   - name: host-spawn
     buildsystem: simple


### PR DESCRIPTION
This makes the app use a Wayland window if launched within a Wayland environment.

Motivation: I use Wayland, and the current version of the app fails to launch with this error:

```
[2:0430/120512.962707:ERROR:ozone_platform_x11.cc(241)] Missing X server or $DISPLAY
[2:0430/120512.962737:ERROR:env.cc(255)] The platform failed to initialize.
```

I could make it work (in an X window via XWayland) if I added an override to remove the `--socket=fallback-x11`. But if I instead add the `--ozone-platform-hint=auto` argument, then it will launch in a Wayland window for preference.

I have done my best to test that the app will still work in regular Xorg sessions, by using Xephyr:

```
$ Xephyr -ac -screen 1024x768 :2 &
$ DISPLAY=:2 flatpak run --nosocket=wayland --env=XDG_SESSION_TYPE=x11 com.useanything.AnythingLLMDesktop
```

This works and launches the app in an X window (within Xephyr). I believe the environment variable and lack of a Wayland socket mimics a regular Xorg environment.